### PR TITLE
Development mode: Fix default mode

### DIFF
--- a/lib/vuejs-rails.rb
+++ b/lib/vuejs-rails.rb
@@ -2,9 +2,9 @@ require "vuejs-rails/version"
 
 module Vue
   mattr_accessor :development_mode
+  self.development_mode = defined?(::Rails) && ::Rails.env.development?
 
   class << self
-    development_mode = defined?(::Rails) && ::Rails.env.development?
     def full_or_minified(asset_name)
       development_mode ? "dist/#{asset_name}.js": "dist/#{asset_name}.min.js"
     end


### PR DESCRIPTION
Expected behaviour:
 - When `Vue.development_mode` is not manually set, its value should be
true when Rails is not in production mode, and false otherwise.

Current behaviour:
 - When `Vue.development_mode` is not manually set, its value is nil,
regardless of whether Rails is in production mode. Thus
Vue.development_mode is falsy and Vue is always loaded in production
mode (minified and without access to debugger).

Cause and fix:
 - `development_mode = ` creates a local variable only accessible
within the class definition scope. Thus the method attribute defined by
`mattr_accessor` is not affected. Prepending the `self` keyword and moving
the assignment into the right scope fixes the issue.