### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/vuejs-rails.gemspec
+++ b/vuejs-rails.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = "A simple asset-pipeline wrapper for vue.js by Evan You"
   s.license     = "MIT"
 
-  s.rubyforge_project = "vuejs-rails"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436